### PR TITLE
Removing asNop() from the Point and Track records

### DIFF
--- a/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/AirborneEvent.java
+++ b/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/AirborneEvent.java
@@ -36,6 +36,7 @@ import org.mitre.openaria.core.PointPair;
 import org.mitre.openaria.core.ScoredInstant;
 import org.mitre.openaria.core.Track;
 import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.core.output.HashUtils;
 import org.mitre.openaria.core.utils.ConflictAngle;
 
@@ -541,8 +542,11 @@ public final class AirborneEvent implements AriaEvent<AirborneEvent> {
     }
 
     private String[] extractRawTrackData(Track track1) {
+
+        NopEncoder nopEncoder = new NopEncoder(); //assumes NOP encoding..
+
         return track1.points().stream()
-            .map(Point::asNop)
+            .map(p -> nopEncoder.asRawNop(p))
             .toArray(String[]::new);
     }
 

--- a/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/DataCleaning.java
+++ b/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/DataCleaning.java
@@ -15,6 +15,7 @@ import org.mitre.caasd.commons.DataCleaner;
 import org.mitre.caasd.commons.Distance;
 import org.mitre.caasd.commons.util.SequentialFileWriter;
 import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.trackpairing.IsFormationFlight;
 import org.mitre.openaria.trackpairing.IsFormationFlight.FormationFilterDefinition;
 
@@ -94,19 +95,25 @@ public class DataCleaning {
      */
     private static class Printer implements Consumer<TrackPair> {
 
-        SequentialFileWriter writer = new SequentialFileWriter();
+        SequentialFileWriter writer;
+
+        NopEncoder nopEncoder;
 
         String filePrefix;
 
         Printer(String outputDir) {
             System.out.println("Making Printer for: " + outputDir);
             this.writer = new SequentialFileWriter(outputDir);
+            this.nopEncoder = new NopEncoder();
             this.filePrefix = outputDir;
         }
 
         @Override
         public void accept(TrackPair t) {
-            writer.write(filePrefix, t.track1().asNop() + t.track2().asNop());
+            writer.write(
+                filePrefix,
+                nopEncoder.asRawNop(t.track1()) + nopEncoder.asRawNop(t.track2())
+            );
         }
     }
 }

--- a/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/SeparationPrediction.java
+++ b/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/SeparationPrediction.java
@@ -16,6 +16,7 @@ import org.mitre.caasd.commons.Speed;
 import org.mitre.openaria.core.ClosestPointOfApproach;
 import org.mitre.openaria.core.PointPair;
 import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.NopEncoder;
 
 /**
  * A AirborneSeparationPredication takes two instantaneous aircraft trajectories and predicts: (1)
@@ -88,8 +89,9 @@ public class SeparationPrediction {
             this.immediateScore = computeImmediateScore();
 
         } catch (NullPointerException npe) {
-            String track1 = trackPair.track1().asNop();
-            String track2 = trackPair.track2().asNop();
+            NopEncoder nopEncoder = new NopEncoder();
+            String track1 = nopEncoder.asRawNop(trackPair.track1());
+            String track2 = nopEncoder.asRawNop(trackPair.track2());
             throw new RuntimeException(track1 + "\n" + track2 + "\n", npe);
         }
     }

--- a/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/AirborneTestUtils.java
+++ b/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/AirborneTestUtils.java
@@ -2,11 +2,12 @@
 package org.mitre.openaria.airborne;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mitre.openaria.airborne.AirborneAria.airborneAria;
 import static org.mitre.caasd.commons.ConsumingCollections.newConsumingArrayList;
+import static org.mitre.openaria.airborne.AirborneAria.airborneAria;
 
-import org.mitre.openaria.core.TrackPair;
 import org.mitre.caasd.commons.ConsumingCollections.ConsumingArrayList;
+import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.NopEncoder;
 
 public class AirborneTestUtils {
 
@@ -37,9 +38,11 @@ public class AirborneTestUtils {
 
             System.out.println(foundEvents.get(0).asJson());
 
-            System.out.println(pair.track1().asNop());
+            NopEncoder nopEncoder = new NopEncoder();
+
+            System.out.println(nopEncoder.asRawNop(pair.track1()));
             System.out.println("");
-            System.out.println(pair.track2().asNop());
+            System.out.println(nopEncoder.asRawNop(pair.track2()));
         }
 
         assertTrue(foundEvents.isEmpty(), "No event expected");

--- a/open-aria-core/src/main/java/org/mitre/openaria/core/IfrVfrAssigner.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/core/IfrVfrAssigner.java
@@ -9,6 +9,7 @@ import static org.mitre.openaria.core.IfrVfrStatus.VFR;
 import java.time.Instant;
 import java.util.Collection;
 
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.core.formats.NopHit;
 
 import com.google.common.collect.EnumMultiset;
@@ -33,6 +34,9 @@ public class IfrVfrAssigner {
      * particular point in time.
      */
     private int numPointsToConsider;
+
+    /** Converts Points into NopPoints so that we can access the toString(). */
+    private final NopEncoder nopEncoder = new NopEncoder();
 
     /**
      * Create an object that can determine the IFR/VFR status of a Track at a particular moment in
@@ -82,9 +86,9 @@ public class IfrVfrAssigner {
      *
      * @return IFR or VFR.
      */
-    public IfrVfrStatus statusOf(Point point) {
+    public IfrVfrStatus statusOf(Point<?> point) {
 
-        Point<NopHit> np = NopHit.from(point.asNop());
+        Point<NopHit> np = NopHit.from(nopEncoder.asRawNop(point));
 
         if (np.rawData().hasValidBeaconActual() && beaconIsVfr(np.rawData().beaconActualAsInt())) {
             return VFR;

--- a/open-aria-core/src/main/java/org/mitre/openaria/core/Point.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/core/Point.java
@@ -13,8 +13,6 @@ import org.mitre.caasd.commons.HasTime;
 import org.mitre.caasd.commons.LatLong;
 import org.mitre.caasd.commons.Position;
 import org.mitre.caasd.commons.Speed;
-import org.mitre.openaria.core.formats.NopEncoder;
-import org.mitre.openaria.core.formats.NopHit;
 import org.mitre.openaria.core.temp.Extras.HasAircraftDetails;
 
 
@@ -43,27 +41,6 @@ public record Point<T>(Position position, Velocity velocity, String trackId,
 
     public Speed speed() {
         return nonNull(velocity) ? velocity.speed() : null;
-    }
-
-
-    /**
-     * @return A String that represent this point as if it were a raw NOP Radar Hit (RH) Message.
-     *     When possible, this method will delegate to the implementing Point class (which may
-     *     contain the raw NOP Message). The default implementation "harvests" the data fields
-     *     available as part of the Point interface and builds a "faux RH Message" from that data.
-     */
-    public String asNop() {
-
-        if(rawData instanceof NopHit np) {
-            return np.rawMessage().rawMessage();
-        }
-
-
-        /*
-         * If the implementing class cannot provide the raw Nop RH Message itself encode whatever
-         * data is available via the Point interface itself.
-         */
-        return (new NopEncoder()).asRawNop(this);
     }
 
     /**

--- a/open-aria-core/src/main/java/org/mitre/openaria/core/Track.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/core/Track.java
@@ -79,21 +79,6 @@ public record Track(NavigableSet<Point> points) implements JsonWritable {
     }
 
     /**
-     * @return A String that represent this Track as if it were a sequence of raw NOP Radar Hit (RH)
-     *     Messages. This method relies on each contained Point object to provide the best possible
-     *     "nop representation" of itself.
-     */
-    public String asNop() {
-
-        //rely on the each point to generate the best possible "nop representation" of itself.
-        StringBuilder sb = new StringBuilder();
-        for (Point point : points()) {
-            sb.append(point.asNop()).append("\n");
-        }
-        return sb.toString();
-    }
-
-    /**
      * @return The minimum TimeWindow that contains all Points within this Track."
      */
     public TimeWindow asTimeWindow() {

--- a/open-aria-core/src/main/java/org/mitre/openaria/core/formats/NopEncoder.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/core/formats/NopEncoder.java
@@ -6,10 +6,13 @@ import static java.util.Objects.nonNull;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import org.mitre.openaria.core.Point;
+import org.mitre.openaria.core.Track;
 import org.mitre.openaria.core.temp.Extras.AircraftDetails;
 import org.mitre.openaria.core.temp.Extras.HasAircraftDetails;
 import org.mitre.openaria.core.temp.Extras.HasBeaconCodes;
@@ -36,6 +39,25 @@ public class NopEncoder {
         return formatter;
     }
 
+
+    /**
+     * @return A String with one line per point.  Each line a single Point as if it were a raw NOP
+     *     Radar Hit (RH) Messages. This method relies on each contained Point object to provide the
+     *     best possible "nop representation" of itself.
+     */
+    public String asRawNop(Collection<Point> points) {
+
+        String combinedString = points.stream()
+            .map(p -> asRawNop(p))
+            .collect(Collectors.joining("\n"));
+
+        return combinedString + "\n";
+    }
+
+    public String asRawNop(Track track) {
+        return asRawNop(track.points());
+    }
+
     /**
      * Note: Consider using a Point's "asNop()" method directly. It is possible the implementing
      * class can provide a better NOP encoding than a NopEncoder can generate. The NopEncoder must
@@ -50,6 +72,10 @@ public class NopEncoder {
      *     is available in any of the NOP formats (AGW, CENTER, or STARS)
      */
     public String asRawNop(Point<?> p) {
+
+        if(p.rawData() instanceof NopHit nop) {
+            return nop.rawMessage().rawMessage();
+        }
 
         AircraftDetails acDetails = null;
         SourceDetails sourceDetails = null;

--- a/open-aria-core/src/main/java/org/mitre/openaria/smoothing/TrackSmoothing.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/smoothing/TrackSmoothing.java
@@ -9,6 +9,7 @@ import org.mitre.caasd.commons.Functions.ToStringFunction;
 import org.mitre.caasd.commons.util.ExceptionHandler;
 import org.mitre.caasd.commons.util.SequentialFileWriter;
 import org.mitre.openaria.core.Track;
+import org.mitre.openaria.core.formats.NopEncoder;
 
 public class TrackSmoothing {
 
@@ -28,8 +29,6 @@ public class TrackSmoothing {
              * only the trailing points)
              */
             new TimeDownSampler(Duration.ofMillis(4_000)),
-            //correct missing speed values
-//            new FillMissingSpeeds(),
             //removes near-stationary Tracks produces by "radar mirages" off of skyscrapers and such
             new RemoveLowVariabilityTracks(),
             //removes near-duplicate points when a track is stationary.
@@ -49,8 +48,10 @@ public class TrackSmoothing {
 
     public static DataCleaner<Track> simpleSmoothing() {
 
+        NopEncoder nopEncoder = new NopEncoder();
+
         DataCleaner<Track> cleaner = coreSmoothing();
-        ToStringFunction<Track> toString = track -> track.asNop();
+        ToStringFunction<Track> toString = track -> nopEncoder.asRawNop(track);
         ExceptionHandler exceptionHandler = new SequentialFileWriter("trackCleaningExceptions");
 
         return new ExceptionCatchingCleaner<>(cleaner, toString, exceptionHandler);

--- a/open-aria-core/src/test/java/org/mitre/openaria/core/NopPointsTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/core/NopPointsTest.java
@@ -11,6 +11,7 @@ import static org.mitre.openaria.core.formats.nop.NopParsingUtils.parseNopTime;
 
 import java.util.Optional;
 
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.core.formats.NopHit;
 import org.mitre.openaria.core.formats.nop.AgwRadarHit;
 import org.mitre.openaria.core.formats.nop.CenterRadarHit;
@@ -166,10 +167,12 @@ public class NopPointsTest {
         Point<NopHit> agw = NopHit.from(AGW_RH_MESSAGE);
         Point<NopHit> mearts = NopHit.from(MEARTS_RH_MESSAGE);
 
-        assertEquals(CENTER_RH_MESSAGE, center.asNop());
-        assertEquals(STARS_RH_MESSAGE, stars.asNop());
-        assertEquals(AGW_RH_MESSAGE, agw.asNop());
-        assertEquals(MEARTS_RH_MESSAGE, mearts.asNop());
+        NopEncoder nopEncoder = new NopEncoder();
+
+        assertEquals(CENTER_RH_MESSAGE, nopEncoder.asRawNop(center));
+        assertEquals(STARS_RH_MESSAGE, nopEncoder.asRawNop(stars));
+        assertEquals(AGW_RH_MESSAGE, nopEncoder.asRawNop(agw));
+        assertEquals(MEARTS_RH_MESSAGE, nopEncoder.asRawNop(mearts));
     }
 
     @Test

--- a/open-aria-core/src/test/java/org/mitre/openaria/core/TestUtils.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/core/TestUtils.java
@@ -2,11 +2,14 @@
 package org.mitre.openaria.core;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Set;
+
+import org.mitre.openaria.core.formats.NopEncoder;
 
 public class TestUtils {
 
@@ -29,11 +32,11 @@ public class TestUtils {
 
         Set<String> arrayOfPoints = newHashSet(expectedPoints);
 
+        NopEncoder nopEncoder = new NopEncoder();
+
         for (Point actualResult : actualResults) {
-            assertTrue(
-                arrayOfPoints.contains(actualResult.asNop()),
-                "The actualResult:\n" + actualResult.asNop() + " \nwas not found in the array of expected points"
-            );
+            String asNop = nopEncoder.asRawNop(actualResult);
+            assertThat(arrayOfPoints.contains(asNop), is(true));
         }
     }
 

--- a/open-aria-core/src/test/java/org/mitre/openaria/core/TracksTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/core/TracksTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 import org.mitre.caasd.commons.LatLong;
 import org.mitre.caasd.commons.TimeWindow;
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.core.formats.NopHit;
 import org.mitre.openaria.core.temp.Extras.AircraftDetails;
 import org.mitre.openaria.core.temp.Extras.HasAircraftDetails;
@@ -40,9 +41,11 @@ public class TracksTest {
 
         Track track = Track.of( (List) points);
 
+        NopEncoder nopEncoder = new NopEncoder();
+
         assertEquals(
             raw1 + "\n" + raw2 + "\n" + raw3 + "\n",
-            track.asNop()
+            nopEncoder.asRawNop(track.points())
         );
     }
 
@@ -74,11 +77,13 @@ public class TracksTest {
 
         Track track = Track.of(points);
 
+        NopEncoder nopEncoder = new NopEncoder();
+
         assertEquals(
             "[RH],STARS,,01/01/1970,00:00:00.000,,,,,,,,0.00000,1.00000,null,,,,,,,,,,,,,,,,,,,,,,,,,,{RH}\n"
                 + "[RH],STARS,,01/01/1970,00:00:04.000,AA123,BOEING,,,,,,0.00000,1.00000,null,,,,,,,,,,,,,,,,,,,,,,,,,,{RH}\n"
                 + "[RH],STARS,,01/01/1970,00:00:08.000,,,,,,,,0.00000,1.00000,null,,,,,,,,,,,,,,,,,,,,,,,,,,{RH}\n",
-            track.asNop()
+            nopEncoder.asRawNop(track.points())
         );
     }
 

--- a/open-aria-core/src/test/java/org/mitre/openaria/smoothing/LateralOutlierDetectorTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/smoothing/LateralOutlierDetectorTest.java
@@ -21,6 +21,7 @@ import org.mitre.caasd.commons.LatLong;
 import org.mitre.caasd.commons.Speed;
 import org.mitre.openaria.core.Point;
 import org.mitre.openaria.core.Track;
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.core.formats.NopHit;
 
 import org.junit.jupiter.api.Test;
@@ -128,8 +129,8 @@ public class LateralOutlierDetectorTest {
         String outlier2 = "[RH],STARS,ABE_B,03/25/2018,21:45:18.207,N317A,SR22,,0224,033,170,269,040.48656,-075.97119,2326,0224,-24.2925,-9.8784,0,4,A,ABE,RDG,PTW,ABE,2114,ABE,ACT,VFR,,00957,,,,,,S,1,,0,{RH}";
 
         Set<String> knownOutliers = newHashSet(
-            NopHit.from(outlier1).asNop(),
-            NopHit.from(outlier2).asNop()
+            outlier1,
+            outlier2
         );
 
         Track testTrack = createTrackFromFile(
@@ -140,9 +141,12 @@ public class LateralOutlierDetectorTest {
         NavigableSet<Point> outliers = outlierDetector.getOutliers(testTrack);
 
         assertEquals(2, outliers.size(), "We found exactly 2 outliers");
+
+        NopEncoder nopEncoder = new NopEncoder();
+
         //and they are the two shown above
-        for (Point outlier : outliers) {
-            assertTrue(knownOutliers.contains(outlier.asNop()));
+        for (Point<?> outlier : outliers) {
+            assertTrue(knownOutliers.contains(nopEncoder.asRawNop(outlier)));
         }
 
         //using the outlierDetector's "clean" method will mutate the input, save the prior state

--- a/open-aria-core/src/test/java/org/mitre/openaria/smoothing/VerticalOutlierDetectorTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/smoothing/VerticalOutlierDetectorTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import org.mitre.openaria.core.Point;
 import org.mitre.openaria.core.Track;
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.core.formats.NopHit;
 import org.mitre.openaria.smoothing.VerticalOutlierDetector.AnalysisResult;
 
@@ -218,9 +219,11 @@ public class VerticalOutlierDetectorTest {
 
     private void confirmExactlyTheseOutliers(Collection<AnalysisResult> foundOutliers, String... expectedOutliters) {
 
+        NopEncoder nopEncoder = new NopEncoder();
+
         Set<String> knownOutliers = Stream.of(expectedOutliters)
             .map(asRawNop -> NopHit.from(asRawNop)) //convert the raw Nop to Points
-            .map(Point -> Point.asNop()) //get the "lossy" Strings
+            .map(p -> nopEncoder.asRawNop(p)) //get the "lossy" Strings
             .collect(toCollection(HashSet::new)); //in a HashSet
 
         Collection<Point> outlieingPoints = foundOutliers.stream()
@@ -230,7 +233,7 @@ public class VerticalOutlierDetectorTest {
         assertThat(foundOutliers.size(), is(expectedOutliters.length));
 
         for (Point foundOutlier : outlieingPoints) {
-            assertTrue(knownOutliers.contains(foundOutlier.asNop()));
+            assertTrue(knownOutliers.contains(nopEncoder.asRawNop(foundOutlier)));
         }
 
         assertEquals(

--- a/open-aria-pairing/src/test/java/org/mitre/openaria/trackpairing/TrackPairerTest.java
+++ b/open-aria-pairing/src/test/java/org/mitre/openaria/trackpairing/TrackPairerTest.java
@@ -25,6 +25,7 @@ import org.mitre.openaria.core.Point;
 import org.mitre.openaria.core.PointIterator;
 import org.mitre.openaria.core.Track;
 import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.NopEncoder;
 import org.mitre.openaria.core.formats.nop.NopParser;
 import org.mitre.openaria.threading.TrackMaker;
 
@@ -100,10 +101,14 @@ public class TrackPairerTest {
         assertEquals(t1.size(), t2.size());
         NavigableSet<? extends Point> t1Points = newTreeSet(t1.points());
         NavigableSet<? extends Point> t2Points = newTreeSet(t2.points());
+
+        NopEncoder nopEncoder = new NopEncoder();
+
         while (!t1Points.isEmpty()) {
-            Point t1Point = t1Points.pollFirst();
-            Point t2Point = t2Points.pollFirst();
-            assertEquals(t1Point.asNop(), t2Point.asNop());
+            Point p1Pnt = t1Points.pollFirst();
+            Point t2Pnt = t2Points.pollFirst();
+            assertThat(nopEncoder.asRawNop(p1Pnt), is(nopEncoder.asRawNop(t2Pnt)));
+
         }
     }
 


### PR DESCRIPTION
Now that OpenARIA is targeting multiple data formats it is inappropriate for Point and Track records to directly support writing to a particular data format. We can move this responsibility to a dedicated NopEncoder class and achieve a better break down of responsibilities