### PR TITLE
Now supporting "-Xlint" options in gradle builds

### DIFF
--- a/open-aria-core/open-aria-core.gradle.kts
+++ b/open-aria-core/open-aria-core.gradle.kts
@@ -12,6 +12,17 @@ tasks.named<Test>("test") {
     }
 }
 
+
+tasks {
+    withType<JavaCompile> {
+        description = "A place to set javac options, e.g -Xlint."
+
+//        options.compilerArgs.add("-Xdoclint:all,-missing")
+//        options.compilerArgs.add("-Xlint:deprecation")
+        options.compilerArgs.add("-Xlint:unchecked")
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {

--- a/open-aria-core/src/main/java/org/mitre/openaria/core/output/HashUtils.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/core/output/HashUtils.java
@@ -18,7 +18,6 @@ import com.google.gson.JsonParser;
 public class HashUtils {
 
     private static final Gson FLAT_GSON = new Gson();
-    private static final JsonParser PARSER = new JsonParser();
 
     public static final String HASH_FIELD_NAME = "uniqueId";
 
@@ -48,7 +47,7 @@ public class HashUtils {
     static String removeWhiteSpaceFromJson(String json) {
 
         //reparse the JSON to ensure that all whitespace formatting is uniform
-        String flattend = FLAT_GSON.toJson(PARSER.parse(json));
+        String flattend = FLAT_GSON.toJson(JsonParser.parseString(json));
 
         return flattend;
     }

--- a/open-aria-core/src/main/java/org/mitre/openaria/smoothing/TrimLowSpeedPoints.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/smoothing/TrimLowSpeedPoints.java
@@ -16,7 +16,7 @@ import org.mitre.openaria.core.Track;
  * attempting to remove ground-data from Tracks (in cases where you only are interested in the
  * airborne section of a track).
  */
-public class TrimLowSpeedPoints<T> implements DataCleaner<Track> {
+public class TrimLowSpeedPoints implements DataCleaner<Track> {
 
     private final double speedLimitInKnots;
     private final int minNumberPoints;

--- a/open-aria-core/src/test/java/org/mitre/openaria/core/ApproximateTimeSorterTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/core/ApproximateTimeSorterTest.java
@@ -205,7 +205,7 @@ public class ApproximateTimeSorterTest {
     public void testVeryOldPointsAreAutoEvicted() {
         ConsumingArrayList<Point> downstreamConsumer = newConsumingArrayList();
 
-        ApproximateTimeSorter sorter = new ApproximateTimeSorter(
+        ApproximateTimeSorter<Point> sorter = new ApproximateTimeSorter<>(
             Duration.ofSeconds(10),
             downstreamConsumer
         );

--- a/open-aria-core/src/test/java/org/mitre/openaria/core/StrictTimeSortEnforcerTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/core/StrictTimeSortEnforcerTest.java
@@ -110,7 +110,7 @@ public class StrictTimeSortEnforcerTest {
 
         TestConsumer testConsumer = new TestConsumer();
 
-        StrictTimeSortEnforcer sorted = new StrictTimeSortEnforcer(testConsumer);
+        StrictTimeSortEnforcer<Point> sorted = new StrictTimeSortEnforcer<>(testConsumer);
 
         //only points with indice 0, 1, 3, 5, 6 should be delivered
         List<Point> testData = testData(0, 1, -1, 2, -3, 3, 4, -1, 3);
@@ -129,9 +129,9 @@ public class StrictTimeSortEnforcerTest {
     public void testSkippedAreAvailableInLastSkippedPoint() {
 
         TestConsumer testConsumer = new TestConsumer();
-        ConsumingLinkedList rejectionConsumer = newConsumingLinkedList();
+        ConsumingLinkedList<Point> rejectionConsumer = newConsumingLinkedList();
 
-        StrictTimeSortEnforcer sorted = new StrictTimeSortEnforcer(
+        StrictTimeSortEnforcer<Point> sorted = new StrictTimeSortEnforcer<>(
             testConsumer,
             rejectionConsumer
         );

--- a/open-aria-core/src/test/java/org/mitre/openaria/smoothing/HighFrequencyPointRemoverTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/smoothing/HighFrequencyPointRemoverTest.java
@@ -8,9 +8,10 @@ import static org.mitre.openaria.core.Tracks.createTrackFromResource;
 import java.time.Duration;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Test;
-import org.mitre.openaria.core.Track;
 import org.mitre.caasd.commons.DataCleaner;
+import org.mitre.openaria.core.Track;
+
+import org.junit.jupiter.api.Test;
 
 public class HighFrequencyPointRemoverTest {
 
@@ -24,7 +25,7 @@ public class HighFrequencyPointRemoverTest {
 
         Duration MIN_ALLOWABLE_SPACING = Duration.ofMillis(500);
 
-        DataCleaner smoother = new HighFrequencyPointRemover(MIN_ALLOWABLE_SPACING);
+        DataCleaner<Track> smoother = new HighFrequencyPointRemover(MIN_ALLOWABLE_SPACING);
 
         Optional<Track> cleanedTrack = smoother.clean(testTrack);
 
@@ -49,7 +50,7 @@ public class HighFrequencyPointRemoverTest {
 
         Duration MIN_ALLOWABLE_SPACING = Duration.ofMillis(500);
 
-        DataCleaner smoother = new HighFrequencyPointRemover(MIN_ALLOWABLE_SPACING);
+        DataCleaner<Track> smoother = new HighFrequencyPointRemover(MIN_ALLOWABLE_SPACING);
 
         Optional<Track> cleanedTrack = smoother.clean(testTrack);
 
@@ -75,7 +76,7 @@ public class HighFrequencyPointRemoverTest {
 
         Duration MIN_ALLOWABLE_SPACING = Duration.ofSeconds(10);
 
-        DataCleaner smoother = new HighFrequencyPointRemover(MIN_ALLOWABLE_SPACING);
+        DataCleaner<Track> smoother = new HighFrequencyPointRemover(MIN_ALLOWABLE_SPACING);
 
         Optional<Track> cleanedTrack = smoother.clean(testTrack);
 


### PR DESCRIPTION
Corrected two deprecation issues and a few "rawType" warnings from -Xlint.  We want to correct as many warnings as possible before converting Track to a generic records.