### PR TITLE
Updating GitHub Actions to make artifacts accessible

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,11 +36,12 @@ jobs:
     - name: Build with Gradle Wrapper
       run: ./gradlew build shadowJar
 
+    # Make the resulting shadowJar (i.e., uber jar) Accessible via GitHub Packages
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: Package
-        path: build/libs
+        path: open-aria-deploy/build/libs
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,13 @@ jobs:
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 
     - name: Build with Gradle Wrapper
-      run: ./gradlew build
+      run: ./gradlew build shadowJar
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Package
+        path: build/libs
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.


### PR DESCRIPTION
* We can now access the shadowJar via GitHub Packages
* This will facilitate uploading releases for others to use