### PR TITLE
feat: Reinstated ability to copy input data to output events

### DIFF
--- a/open-aria-airborne/open-aria-airborne.gradle.kts
+++ b/open-aria-airborne/open-aria-airborne.gradle.kts
@@ -13,7 +13,7 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 
     testLogging {
-        events("PASSED", "SKIPPED", "FAILED")
+        events("SKIPPED", "FAILED") // Options are: "PASSED", "SKIPPED", "FAILED"
     }
 }
 

--- a/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/AirborneAlgorithmDef.java
+++ b/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/AirborneAlgorithmDef.java
@@ -363,7 +363,7 @@ public class AirborneAlgorithmDef {
 
         private Builder() {
             //exists to enable automatic YAML parsing with Jackson library
-            this.dataFormat = "csv";
+            this.dataFormat = "nop";
             this.hostId = "airborne-compute-1";
             this.maxReportableScore = 20.0;
             this.filterByAirspace = true;
@@ -433,6 +433,7 @@ public class AirborneAlgorithmDef {
         }
 
         public AirborneAlgorithmDef build() {
+            requireNonNull(dataFormat, "AirborneAlgorithmDef's dataFormat must be set");
             return new AirborneAlgorithmDef(this);
         }
     }

--- a/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/AirborneAria.java
+++ b/open-aria-airborne/src/main/java/org/mitre/openaria/airborne/AirborneAria.java
@@ -6,7 +6,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Streams.stream;
 import static java.lang.Math.abs;
 import static java.util.Objects.requireNonNull;
-import static org.mitre.openaria.airborne.AirborneEvent.newBuilder;
 import static org.mitre.openaria.airborne.Snapshot.extractSnapshot;
 import static org.mitre.openaria.airborne.Snapshot.extractSnapshotWithCpa;
 import static org.mitre.openaria.core.SeparationTimeSeries.lateralComparator;
@@ -123,16 +122,15 @@ public class AirborneAria {
             ? tpa.analysis.truncate(algorithmDef.dynamicsInclusionRadius()).serializedForm() :
             null;
 
-        AirborneEvent event = newBuilder()
+        return AirborneEvent.newBuilder()
             .rawTracks(rawPair)
             .smoothedTracks(smoothedPair)
+            .format(algorithmDef.dataFormat())
             .riskiestMoment(tpa.riskiestMoment)
             .snapshots(extractKeyMoments(smoothedPair, tpa))
             .dynamics(dynamics)
             .includeTrackData(algorithmDef.publishTrackData())
             .build();
-
-        return event;
     }
 
     /**

--- a/open-aria-airborne/src/main/resources/sampleCsvConfig.yaml
+++ b/open-aria-airborne/src/main/resources/sampleCsvConfig.yaml
@@ -6,7 +6,7 @@ airborneConfig:
     maxReportableScore: 30.0
     filterByAirspace: true
     publishAirborneDynamics: true
-    publishTrackData: false
+    publishTrackData: true
     requiredDiverganceDistInNM: 0.5
     onGroundSpeedInKnots: 80.0
     requiredTimeOverlapInMs: 7500

--- a/open-aria-airborne/src/main/resources/sampleNopConfig.yaml
+++ b/open-aria-airborne/src/main/resources/sampleNopConfig.yaml
@@ -6,7 +6,7 @@ airborneConfig:
     maxReportableScore: 30.0
     filterByAirspace: true
     publishAirborneDynamics: true
-    publishTrackData: false
+    publishTrackData: true
     requiredDiverganceDistInNM: 0.5
     onGroundSpeedInKnots: 80.0
     requiredTimeOverlapInMs: 7500
@@ -16,6 +16,7 @@ airborneConfig:
     trackSmoothingExpirationSec: 120
     logDuplicateTracks: false
     applySmoothing: true
+#   This requirement reduces the number of output events
     requireDataTag: true
     logFileDirectory: "logs"
     airborneDynamicsRadiusNm: 15.0

--- a/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/AirborneEventTest.java
+++ b/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/AirborneEventTest.java
@@ -16,6 +16,8 @@ import java.time.Instant;
 
 import org.mitre.openaria.core.ScoredInstant;
 import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.Formats;
+import org.mitre.openaria.core.formats.nop.NopHit;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
@@ -27,7 +29,7 @@ public class AirborneEventTest {
     /** Use of pretty printing in default {@link Gson} messes up the test literals */
     static Gson gson = new Gson();
 
-    static TrackPair SCARY_TRACK_PAIR = makeTrackPairFromNopData(getResourceFile("scaryTrackData.txt"));
+    static TrackPair<NopHit> SCARY_TRACK_PAIR = makeTrackPairFromNopData(getResourceFile("scaryTrackData.txt"));
 
     static ScoredInstant SCORED_INSTANT = new ScoredInstant(
         3.0,
@@ -36,7 +38,7 @@ public class AirborneEventTest {
 
     @Test
     public void toJson_fromJson_cycleIsConsistent() {
-        AirborneEvent record = new AirborneEvent(SCARY_TRACK_PAIR, SCORED_INSTANT);
+        AirborneEvent record = new AirborneEvent(SCARY_TRACK_PAIR, Formats.nop(), SCORED_INSTANT);
 
         String json = record.asJson();
 
@@ -82,6 +84,7 @@ public class AirborneEventTest {
     public void ToJson_WithAirborneDynamics_Correct() {
         AirborneEvent record = newBuilder()
             .rawTracks(SCARY_TRACK_PAIR)
+            .format(Formats.nop())
             .riskiestMoment(SCORED_INSTANT)
             .snapshots(new Snapshot[]{null, null, null, null, null, null})
             .dynamics(AirborneDynamicsTest.asObj)
@@ -94,7 +97,7 @@ public class AirborneEventTest {
 
     @Test
     public void ToJson_WithoutAirborneDynamics_Correct() {
-        AirborneEvent record = new AirborneEvent(SCARY_TRACK_PAIR, SCORED_INSTANT);
+        AirborneEvent record = new AirborneEvent(SCARY_TRACK_PAIR, Formats.nop(), SCORED_INSTANT);
 
         String json = gson.toJson(record);
 
@@ -103,7 +106,7 @@ public class AirborneEventTest {
 
     @Test
     public void uuidInJsonSameAsUuidFromMethod() {
-        AirborneEvent record = new AirborneEvent(SCARY_TRACK_PAIR, SCORED_INSTANT);
+        AirborneEvent record = new AirborneEvent(SCARY_TRACK_PAIR, Formats.nop(), SCORED_INSTANT);
 
         String uuidFromApi = record.uuid();
         String hashFromJson = new JsonParser().parse(record.asJson())

--- a/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/AirborneTestUtils.java
+++ b/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/AirborneTestUtils.java
@@ -16,7 +16,7 @@ public class AirborneTestUtils {
      *
      * @param pair A test TrackPair
      */
-    public static void confirmNoAirborneEventsAreDetected(TrackPair pair) {
+    public static void confirmNoAirborneEventsAreDetected(TrackPair<?> pair) {
 
         AirborneAlgorithmDef standardConfig = new AirborneAlgorithmDef();
 
@@ -41,7 +41,7 @@ public class AirborneTestUtils {
             NopEncoder nopEncoder = new NopEncoder();
 
             System.out.println(nopEncoder.asRawNop(pair.track1()));
-            System.out.println("");
+            System.out.println();
             System.out.println(nopEncoder.asRawNop(pair.track2()));
         }
 

--- a/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/BadAltitudeDataTest.java
+++ b/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/BadAltitudeDataTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mitre.caasd.commons.fileutil.FileUtils.getResourceFile;
 import static org.mitre.openaria.threading.TrackMaking.makeTrackPairFromNopData;
 
-import java.util.NavigableSet;
-
 import org.mitre.caasd.commons.DataCleaner;
 import org.mitre.caasd.commons.Distance;
 import org.mitre.openaria.core.Point;
@@ -36,14 +34,14 @@ public class BadAltitudeDataTest {
         //This is the Track cleaner that is used to
         DataCleaner<Track> cleaner = props.singleTrackCleaner();
 
-        for (TrackPair pair : getTrackPairsContainingAFlawedAltitudePoint()) {
+        for (TrackPair<?> pair : getTrackPairsContainingAFlawedAltitudePoint()) {
             confirmAtLeastOneTrackContainsJumpyAltitudeData(pair);
             confirmTrackContainSmoothAltitudeData(cleaner.clean(pair.track1()).get());
             confirmTrackContainSmoothAltitudeData(cleaner.clean(pair.track2()).get());
         }
     }
 
-    private void confirmAtLeastOneTrackContainsJumpyAltitudeData(TrackPair testCase) {
+    private void confirmAtLeastOneTrackContainsJumpyAltitudeData(TrackPair<?> testCase) {
 
         Distance QUALIFYING_ALTITUDE_JUMP = Distance.ofFeet(400);
 
@@ -54,18 +52,18 @@ public class BadAltitudeDataTest {
         );
     }
 
-    private void confirmTrackContainSmoothAltitudeData(Track track) {
+    private void confirmTrackContainSmoothAltitudeData(Track<?> track) {
 
         Distance QUALIFYING_JUMP = Distance.ofFeet(400);
 
         assertFalse(containsAltitudeJump(track, QUALIFYING_JUMP));
     }
 
-    private boolean containsAltitudeJump(Track track, Distance qualifingJump) {
+    private boolean containsAltitudeJump(Track<?> track, Distance qualifingJump) {
 
-        Point lastPoint = null;
+        Point<?> lastPoint = null;
 
-        for (Point point : (NavigableSet<Point>) track.points()) {
+        for (Point<?> point : track.points()) {
             if (lastPoint == null) {
                 lastPoint = point;
                 continue;

--- a/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/DuplicateCenterTrackFilteringTest.java
+++ b/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/DuplicateCenterTrackFilteringTest.java
@@ -1,12 +1,14 @@
 
 package org.mitre.openaria.airborne;
 
+import static org.mitre.caasd.commons.fileutil.FileUtils.getResourceFile;
 import static org.mitre.openaria.airborne.AirborneTestUtils.confirmNoAirborneEventsAreDetected;
 import static org.mitre.openaria.threading.TrackMaking.makeTrackPairFromNopData;
-import static org.mitre.caasd.commons.fileutil.FileUtils.getResourceFile;
+
+import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.nop.NopHit;
 
 import org.junit.jupiter.api.Test;
-import org.mitre.openaria.core.TrackPair;
 
 /**
  * The purpose of this testing suite is to confirm that efforts to filter out duplicate Track
@@ -33,7 +35,7 @@ public class DuplicateCenterTrackFilteringTest {
 
         for (String fileName : examplesOfBuggedBehavior) {
 
-            TrackPair trackPair = makeTrackPairFromNopData(getResourceFile(fileName));
+            TrackPair<NopHit> trackPair = makeTrackPairFromNopData(getResourceFile(fileName));
 
             confirmNoAirborneEventsAreDetected(trackPair);
         }

--- a/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/LevelOverflightTest.java
+++ b/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/LevelOverflightTest.java
@@ -3,19 +3,21 @@ package org.mitre.openaria.airborne;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.mitre.caasd.commons.ConsumingCollections.newConsumingArrayList;
+import static org.mitre.caasd.commons.fileutil.FileUtils.getResourceFile;
 import static org.mitre.openaria.airborne.AirborneAlgorithmDef.defaultBuilder;
 import static org.mitre.openaria.airborne.AirborneAria.airborneAria;
 import static org.mitre.openaria.threading.TrackMaking.makeTrackPairFromNopData;
-import static org.mitre.caasd.commons.ConsumingCollections.newConsumingArrayList;
-import static org.mitre.caasd.commons.fileutil.FileUtils.getResourceFile;
+
+import org.mitre.caasd.commons.ConsumingCollections.ConsumingArrayList;
+import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.nop.NopHit;
 
 import org.junit.jupiter.api.Test;
-import org.mitre.openaria.core.TrackPair;
-import org.mitre.caasd.commons.ConsumingCollections.ConsumingArrayList;
 
 public class LevelOverflightTest {
 
-    TrackPair testPair = makeTrackPairFromNopData(
+    TrackPair<NopHit> testPair = makeTrackPairFromNopData(
         getResourceFile("ZFW--level-overflight.txt")
     );
 

--- a/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/MissingBeaconCodeTest.java
+++ b/open-aria-airborne/src/test/java/org/mitre/openaria/airborne/MissingBeaconCodeTest.java
@@ -9,6 +9,8 @@ import java.time.Instant;
 
 import org.mitre.openaria.core.ScoredInstant;
 import org.mitre.openaria.core.TrackPair;
+import org.mitre.openaria.core.formats.Formats;
+import org.mitre.openaria.core.formats.nop.NopHit;
 import org.mitre.openaria.threading.TrackMaking;
 
 import org.junit.jupiter.api.Test;
@@ -25,14 +27,14 @@ public class MissingBeaconCodeTest {
 
         Instant eventTime = Instant.ofEpochMilli(1476830107500L);
 
-        TrackPair eventWithoutBeacon = TrackMaking.makeTrackPairFromNopData(
+        TrackPair<NopHit> eventWithoutBeacon = TrackMaking.makeTrackPairFromNopData(
             getResourceFile("eventWithoutBeaconCode.txt")
         );
 
         double arbitraryScore = 5.0;
         ScoredInstant si = new ScoredInstant(arbitraryScore, eventTime);
 
-        AirborneEvent airborneEvent = new AirborneEvent(eventWithoutBeacon, si);
+        AirborneEvent airborneEvent = new AirborneEvent(eventWithoutBeacon, Formats.nop(), si);
 
         assertThat(airborneEvent.firstAircraft().beaconCode(), is("UNKNOWN"));
         assertThat(airborneEvent.secondAircraft().beaconCode(), is("1462"));

--- a/open-aria-core/open-aria-core.gradle.kts
+++ b/open-aria-core/open-aria-core.gradle.kts
@@ -12,7 +12,7 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 
     testLogging {
-        events("PASSED", "SKIPPED", "FAILED")
+        events("SKIPPED", "FAILED") // Options are: "PASSED", "SKIPPED", "FAILED"
     }
 }
 

--- a/open-aria-core/src/main/java/org/mitre/openaria/core/formats/Format.java
+++ b/open-aria-core/src/main/java/org/mitre/openaria/core/formats/Format.java
@@ -5,6 +5,7 @@ import java.util.Base64;
 import java.util.Iterator;
 
 import org.mitre.openaria.core.Point;
+import org.mitre.openaria.core.Track;
 
 /**
  * A format allows OpenARIA to convert an arbitrary File of input location data into a sequence of
@@ -37,5 +38,15 @@ public interface Format<T> {
     /** Uses java.util.Base64's unpadded url dencoder to interpret a json-friendly String. */
     static byte[] fromBase64(String base64Encoding) {
         return Base64.getUrlDecoder().decode(base64Encoding);
+    }
+
+    /**
+     * Convert a Track made from location data of type T into an array of Strings.  This
+     * implementation relies on the asRawString(T) method.
+     */
+    default String[] asRawStrings(Track<T> track) {
+        return track.points().stream()
+            .map(pt -> asRawString(pt.rawData()))
+            .toArray(String[]::new);
     }
 }

--- a/open-aria-core/src/test/java/org/mitre/openaria/core/TrackPairTest.java
+++ b/open-aria-core/src/test/java/org/mitre/openaria/core/TrackPairTest.java
@@ -28,7 +28,7 @@ public class TrackPairTest {
         Track<NopHit> track1 = Track.of(newArrayList(P1, P2, P3));
         Track<NopHit> track2 = Track.of(newArrayList(P4, P5, P6));
 
-        TrackPair pair = new TrackPair(track1, track2);
+        TrackPair<NopHit> pair = new TrackPair<>(track1, track2);
         assertEquals(pair.track1(), track1);
         assertEquals(pair.track2(), track2);
     }
@@ -39,7 +39,7 @@ public class TrackPairTest {
         Track<NopHit> track1 = Track.of(newArrayList(P1, P2, P3));
         Track<NopHit> track2 = Track.of(newArrayList(P4, P5, P6));
 
-        TrackPair pair = TrackPair.of(track1, track2);
+        TrackPair<NopHit> pair = TrackPair.of(track1, track2);
         assertEquals(pair.track1(), track1);
         assertEquals(pair.track2(), track2);
     }
@@ -91,7 +91,7 @@ public class TrackPairTest {
 
         ArrayList<Track<NopHit>> tracks = newArrayList(fullTrack, earlyTrack);
 
-        TrackPair pair = TrackPair.from(tracks);
+        TrackPair<NopHit> pair = TrackPair.from(tracks);
 
         assertNotEquals(pair.track1(), pair.track2());
         assertTrue(pair.track1() == earlyTrack || pair.track2() == earlyTrack);

--- a/open-aria-pairing/open-aria-pairing.gradle.kts
+++ b/open-aria-pairing/open-aria-pairing.gradle.kts
@@ -9,7 +9,7 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 
     testLogging {
-        events("PASSED", "SKIPPED", "FAILED")
+        events("SKIPPED", "FAILED") // Options are: "PASSED", "SKIPPED", "FAILED"
     }
 }
 

--- a/open-aria-system/open-aria-system.gradle.kts
+++ b/open-aria-system/open-aria-system.gradle.kts
@@ -11,7 +11,7 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 
     testLogging {
-        events("PASSED", "SKIPPED", "FAILED")
+        events("SKIPPED", "FAILED") // Options are: "PASSED", "SKIPPED", "FAILED"
     }
 }
 

--- a/open-aria-threading/open-aria-threading.gradle.kts
+++ b/open-aria-threading/open-aria-threading.gradle.kts
@@ -7,7 +7,7 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 
     testLogging {
-        events("PASSED", "SKIPPED", "FAILED")
+        events("SKIPPED", "FAILED") // Options are: "PASSED", "SKIPPED", "FAILED"
     }
 }
 


### PR DESCRIPTION
* Use the "publishTrackData" option in the yaml config to copy input
* Gradle builds no longer showing passing tests
* Build Errors and Warnings are now easier to see
* Fixed various Unchecked cast warnings