### PR TITLE
feat: Create OpenARIA helm chart for distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,47 @@ jobs:
           majorList: feat!
           minorList: feat
           patchList: fix
+          noVersionBumpBehavior: patch
+          noNewCommitBehavior: silent
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build OpenARIA Jar
+        run: ./gradlew :open-aria-deploy:shadowJar
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io/mitre-public/open-aria
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: azure/setup-helm@v4.3.0
+      - name: Publish OpenARIA Helm Chart
+        run: |
+          helm package open-aria-deploy/helm --version ${{ steps.version.outputs.nextStrict }}
+          helm push open-aria-${{ steps.version.outputs.nextStrict }}.tgz oci://ghcr.io/mitre-public/open-aria/charts
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/mitre-public/open-aria
+          tags: ${{ steps.version.outputs.nextStrict }}
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+          context: open-aria-deploy
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Create GitHub Release
         env:
@@ -32,3 +73,11 @@ jobs:
         run: |
           git tag ${TAG} ${GITHUB_SHA}
           git push origin ${TAG}
+
+      - name: Upload Release Artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload ${{ steps.version.outputs.nextStrict }} \
+          open-aria-deploy/build/libs/open-aria-uber.jar#OpenARIA-${{ steps.version.outputs.nextStrict }}.jar \
+          open-aria-${{ steps.version.outputs.nextStrict }}.tgz

--- a/open-aria-deploy/.dockerignore
+++ b/open-aria-deploy/.dockerignore
@@ -1,0 +1,14 @@
+*.jar
+*.class
+*.ipynb
+.kotlin
+build/
+*.secret
+*.gitignore
+*.md
+bin/
+gradle/wrapper/
+ci-scripts/
+bamboo-specs/
+gradlew*
+sonar*

--- a/open-aria-deploy/Dockerfile
+++ b/open-aria-deploy/Dockerfile
@@ -1,0 +1,14 @@
+FROM gradle:8.12-jdk17 AS build
+
+WORKDIR /open-aria
+COPY ../ .
+
+RUN --mount=type=cache,target=/home/gradle/.gradle/caches \
+    gradle --no-daemon --quiet :open-aria-deploy:shadowJar \
+    && mv open-aria-deploy/build/libs/open-aria-uber.jar ./OpenARIA.jar
+
+FROM eclipse-temurin:17-jre-ubi9-minimal AS deploy
+
+WORKDIR open-aria
+COPY --from=build /open-aria/OpenARIA.jar .
+ENTRYPOINT ["java", "-jar", "/open-aria/OpenARIA.jar"]

--- a/open-aria-deploy/helm/.helmignore
+++ b/open-aria-deploy/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/open-aria-deploy/helm/Chart.yaml
+++ b/open-aria-deploy/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: open-aria
+description: A Helm chart for deploying OpenARIA
+type: application
+version: 0.0.0

--- a/open-aria-deploy/helm/templates/_helpers.tpl
+++ b/open-aria-deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,92 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "open-aria.name" -}}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "open-aria.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "open-aria.labels" -}}
+helm.sh/chart: {{ include "open-aria.chart" . }}
+{{ include "open-aria.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "open-aria.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "open-aria.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Hashed Config Map
+*/}}
+{{- define "open-aria.configSha256" -}}
+{{ .Values.configuration | toYaml | sha256sum | trunc 8 }}
+{{- end }}
+{{- define "open-aria.configMapName" -}}
+{{- printf "%s-%s" (.Chart.Name)  (include "open-aria.configSha256" .) }}
+{{- end }}
+
+
+{{/*
+aria.yaml template
+*/}}
+{{- define "ariaConfigTemplate" -}}
+inputKafkaPropFile: /config/consumer.properties
+kafkaPartitionMappingFile: /config/partitions.txt
+loggingPeriodSec: {{ .Values.configuration.aria.yaml.loggingPeriodSec }}
+logSinkSuppliers:
+  - pluginClass: org.mitre.openaria.airborne.config.StdOutSinkSupplier
+airborneConfig:
+  algorithmDef:
+    dataFormat: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.dataFormat }}
+    hostId: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.hostId }}
+    maxReportableScore: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.maxReportableScore }}
+    filterByAirspace: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.filterByAirspace }}
+    requiredDiverganceDistInNM: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.requiredDiverganceDistInNM }}
+    onGroundSpeedInKnots: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.onGroundSpeedInKnots }}
+    requiredTimeOverlapInMs: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.requiredTimeOverlapInMs }}
+    formationFilters: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.formationFilters }}
+    requiredProximityInNM: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.requiredProximityInNM }}
+    sizeOfTrackSmoothingCache: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.sizeOfTrackSmoothingCache }}
+    trackSmoothingExpirationSec: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.trackSmoothingExpirationSec }}
+    logDuplicateTracks: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.logDuplicateTracks }}
+    applySmoothing: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.applySmoothing }}
+    requireDataTag: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.requireDataTag }}
+    publishAirborneDynamics: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.publishAirborneDynamics }}
+    publishTrackData: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.publishTrackData }}
+    verbose: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.verbose }}
+    logFileDirectory: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.logFileDirectory }}
+    airborneDynamicsRadiusNm: {{ .Values.configuration.aria.yaml.airborneConfig.algorithmDef.airborneDynamicsRadiusNm }}
+  trackPairingDistanceInNM: {{ .Values.configuration.aria.yaml.airborneConfig.trackPairingDistanceInNM }}
+  inMemorySortBufferSec: {{ .Values.configuration.aria.yaml.airborneConfig.inMemorySortBufferSec}}
+outputConfig:
+  outputSinkSuppliers:
+    - pluginClass: org.mitre.openaria.airborne.config.AirborneKafkaSinkSupplier
+      configOptions:
+        topic: {{ .Values.configuration.aria.yaml.airborneEventsTopic }}
+        kafkaPropFile: /config/producer.properties
+        kafkaPartitionMappingFile: /config/partitions.txt
+dataProcessingOptions:
+  pointPrefetchLimit: {{ .Values.configuration.aria.yaml.dataProcessingOptions.pointPrefetchLimit }}
+  numWorkerThreads: {{ .Values.configuration.aria.yaml.dataProcessingOptions.numWorkerThreads }}
+  milliSecBtwPollAttempts: {{ .Values.configuration.aria.yaml.dataProcessingOptions.milliSecBtwPollAttempts }}
+  useConsumerGroups: {{ .Values.configuration.aria.yaml.dataProcessingOptions.useConsumerGroups }}
+  minPartition: {{ .Values.configuration.aria.yaml.dataProcessingOptions.minPartition }}
+  maxPartition: {{ .Values.configuration.aria.yaml.dataProcessingOptions.maxPartition }}
+  pointTopic: {{ .Values.configuration.aria.yaml.pointTopic }}
+{{- end -}}

--- a/open-aria-deploy/helm/templates/config.yaml
+++ b/open-aria-deploy/helm/templates/config.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "open-aria.configMapName" . }}
+  namespace: {{ .Values.namespace }}
+data:
+  consumer.properties: {{ .Values.configuration.kafka.consumer.properties | quote }}
+  producer.properties: {{ .Values.configuration.kafka.producer.properties | quote }}
+  partitions.txt: {{ .Values.configuration.partitions.mapping | quote }}
+  aria.yaml: |
+    {{- include "ariaConfigTemplate" . | nindent 4 }}

--- a/open-aria-deploy/helm/templates/deployment.yaml
+++ b/open-aria-deploy/helm/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "open-aria.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "open-aria.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "open-aria.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: open-aria-config
+          configMap:
+            name: {{ include "open-aria.configMapName" . }}
+            items:
+              - key: consumer.properties
+                path: consumer.properties
+              - key: producer.properties
+                path: producer.properties
+              - key: partitions.txt
+                path: partitions.txt
+              - key: aria.yaml
+                path: aria.yaml
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
+          volumeMounts:
+            - name: open-aria-config
+              mountPath: /config
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - {{ .Values.configuration.aria.yaml.entrypoint }}
+            - /config/aria.yaml
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/open-aria-deploy/helm/templates/serviceaccount.yaml
+++ b/open-aria-deploy/helm/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    {{- include "open-aria.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/open-aria-deploy/helm/values.yaml
+++ b/open-aria-deploy/helm/values.yaml
@@ -1,0 +1,267 @@
+image:
+  repository: mitre/open-aria
+  pullPolicy: IfNotPresent
+
+namespace: default
+imagePullSecrets: []
+podAnnotations: { }
+podLabels: { }
+podSecurityContext: { }
+securityContext: { }
+nodeSelector: { }
+tolerations: [ ]
+affinity: { }
+
+serviceAccount:
+  automount: true
+  annotations: { }
+  name: "open-aria"
+
+resources:
+  requests:
+    cpu: 1000m
+    memory: 5Gi
+  limits:
+    cpu: 1500m
+    memory: 8Gi
+
+configuration:
+  kafka:
+    producer:
+      properties: |
+    consumer:
+      properties: |
+  aria:
+    yaml:
+      entrypoint: org.mitre.openaria.RunAirborneOnKafkaNop
+      pointTopic: aria-points-topic
+      airborneEventsTopic: aria-airborne-events
+      loggingPeriodSec: 300
+      dataProcessingOptions:
+        pointPrefetchLimit: 500000
+        numWorkerThreads: 2
+        milliSecBtwPollAttempts: 2000
+        useConsumerGroups: false
+        minPartition: 0
+        maxPartition: 1
+      airborneConfig:
+        algorithmDef:
+          dataFormat: "nop"
+          hostId: "open-aria"
+          maxReportableScore: 30.0
+          filterByAirspace: true
+          publishAirborneDynamics: true
+          publishTrackData: true
+          requiredDiverganceDistInNM: 0.5
+          onGroundSpeedInKnots: 80.0
+          requiredTimeOverlapInMs: 7500
+          formationFilters: "0.5,60,false"
+          requiredProximityInNM: 7.5
+          sizeOfTrackSmoothingCache: 500
+          trackSmoothingExpirationSec: 120
+          logDuplicateTracks: false
+          applySmoothing: true
+          requireDataTag: false
+          airborneDynamicsRadiusNm: 15.0
+          verbose: false
+        trackPairingDistanceInNM: 8.33
+        inMemorySortBufferSec: 600
+
+  partitions:
+    mapping: |
+      A11 : 0
+      A80 : 1
+      A90 : 2
+      ABE : 3
+      ABI : 4
+      ABQ : 5
+      ACK : 6
+      ACT : 7
+      ACY : 8
+      AGS : 9
+      ALB : 10
+      ALO : 11
+      AMA : 12
+      ANC : 13
+      ASE : 14
+      AUS : 15
+      AVL : 16
+      AVP : 17
+      AZO : 18
+      BFL : 19
+      BGM : 20
+      BGR : 21
+      BHM : 22
+      BIL : 23
+      BIS : 24
+      BNA : 25
+      BOI : 26
+      BTR : 27
+      BTV : 28
+      BUF : 29
+      C90 : 30
+      CAE : 31
+      CAK : 32
+      CHA : 33
+      CHS : 34
+      CID : 35
+      CKB : 36
+      CLE : 37
+      CLT : 38
+      CMH : 39
+      CMI : 40
+      COS : 41
+      COU : 42
+      CPR : 43
+      CRP : 44
+      CRW : 45
+      CVG : 46
+      D01 : 47
+      D10 : 48
+      D21 : 49
+      DAB : 50
+      DLH : 51
+      DSM : 52
+      ELM : 53
+      ELP : 54
+      ERI : 55
+      EUG : 56
+      EVV : 57
+      F11 : 58
+      FAI : 59
+      FAR : 60
+      FAT : 61
+      FAY : 62
+      FLO : 63
+      FMH : 64
+      FNT : 65
+      FSD : 66
+      FSM : 67
+      FWA : 68
+      FYV : 69
+      G90 : 70
+      GEG : 71
+      GGG : 72
+      GPT : 73
+      GRB : 74
+      GRR : 75
+      GSO : 76
+      GSP : 77
+      GTF : 78
+      HSV : 79
+      HTS : 80
+      HUF : 81
+      I90 : 82
+      ICT : 83
+      ILM : 84
+      IND : 85
+      JAN : 86
+      JAX : 87
+      K90 : 88
+      L30 : 89
+      LAN : 90
+      LAS : 91
+      LBB : 92
+      LCH : 93
+      LEX : 94
+      LFT : 95
+      LIT : 96
+      LYH : 97
+      M03 : 98
+      M98 : 99
+      MAF : 100
+      MBS : 101
+      MCI : 102
+      MCO : 103
+      MDT : 104
+      MEM : 105
+      MFD : 106
+      MFR : 107
+      MGM : 108
+      MIA : 109
+      MKE : 110
+      MKG : 111
+      MLI : 112
+      MLU : 113
+      MOB : 114
+      MSN : 115
+      MSO : 116
+      MSY : 117
+      MWH : 118
+      MYR : 119
+      N90 : 120
+      NCT : 121
+      NMM : 122
+      OKC : 123
+      ORF : 124
+      P31 : 125
+      P50 : 126
+      P80 : 127
+      PBI : 128
+      PCT : 129
+      PHL : 130
+      PIA : 131
+      PIT : 132
+      PSC : 133
+      PWM : 134
+      PVD : 135
+      R90 : 136
+      RDG : 137
+      RDU : 138
+      RFD : 139
+      RNO : 140
+      ROA : 141
+      ROC : 142
+      ROW : 143
+      RST : 144
+      RSW : 145
+      S46 : 146
+      S56 : 147
+      SAT : 148
+      SAV : 149
+      SBA : 150
+      SBN : 151
+      SCT : 152
+      SDF : 153
+      SGF : 154
+      SHV : 155
+      SLC : 156
+      SPI : 157
+      SUX : 158
+      SYR : 159
+      T75 : 160
+      TLH : 161
+      TOL : 162
+      TPA : 163
+      TRI : 164
+      TUL : 165
+      TYS : 166
+      U90 : 167
+      Y90 : 168
+      YKM : 169
+      YNG : 170
+      ZAB : 171
+      ZAU : 172
+      ZBW : 173
+      ZDC : 174
+      ZDV : 175
+      ZFW : 176
+      ZHU : 177
+      ZID : 178
+      ZJX : 179
+      ZKC : 180
+      ZLA : 181
+      ZLC : 182
+      ZMA : 183
+      ZME : 184
+      ZMP : 185
+      ZNY : 186
+      ZOA : 187
+      ZOB : 188
+      ZSE : 189
+      ZSU : 190
+      ZTL : 191
+      ZAN : 192
+      ZUA : 193
+      ZHN : 194
+      AZA : 195

--- a/open-aria-kafka/open-aria-kafka.gradle.kts
+++ b/open-aria-kafka/open-aria-kafka.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     api(project(":open-aria-core"))
     api("org.apache.kafka:kafka-clients:2.3.1")
     api("org.apache.kafka:kafka_2.12:2.3.0")
+    api("software.amazon.msk:aws-msk-iam-auth:2.3.1")
 }
 
 publishing {


### PR DESCRIPTION
@politeRaccoon I was bored so I thought I'd take a stab at #42 since I'd like to try and deploy this to EKS eventually.

I wasn't sure if we could get access to the `mitre` dockerhub org or if you wanted to publish as `politeRaccoon/open-aria` so we'll have to update the image name in a couple spots depending on what you decide before merging.

* Updates `release.yaml` to append the OpenARIA shadowJar and chart to the github release automatically.
* Adds `api("software.amazon.msk:aws-msk-iam-auth:2.3.1")` as a dependency to `open-aria-kafka` to allow for connecting to an MSK cluster backed by iam auth.
* Im not completely happy with the way I'm mounting the partition mapping file, but seems like thats going away soon anyway or at least is changing, based on #37? So maybe its ok for now.